### PR TITLE
feat: Add cleanup actions to workspace command

### DIFF
--- a/src/commands/workspace_cleanup_test.zig
+++ b/src/commands/workspace_cleanup_test.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const testing = std.testing;
+const workspace = @import("workspace.zig");
+
+const CleanupStrategy = workspace.CleanupStrategy;
+const CleanupConfig = workspace.CleanupConfig;
+const ProjectType = workspace.ProjectType;
+
+test "CleanupStrategy - fromString and toString" {
+    try testing.expectEqual(CleanupStrategy.conservative, CleanupStrategy.fromString("conservative").?);
+    try testing.expectEqual(CleanupStrategy.moderate, CleanupStrategy.fromString("moderate").?);
+    try testing.expectEqual(CleanupStrategy.aggressive, CleanupStrategy.fromString("aggressive").?);
+    try testing.expectEqual(@as(?CleanupStrategy, null), CleanupStrategy.fromString("invalid"));
+
+    try testing.expectEqualStrings("conservative", CleanupStrategy.conservative.toString());
+    try testing.expectEqualStrings("moderate", CleanupStrategy.moderate.toString());
+    try testing.expectEqualStrings("aggressive", CleanupStrategy.aggressive.toString());
+}
+
+test "CleanupConfig - default values" {
+    const config = CleanupConfig{};
+
+    try testing.expectEqual(false, config.dry_run);
+    try testing.expectEqual(CleanupStrategy.conservative, config.strategy);
+    try testing.expectEqual(@as(?ProjectType, null), config.project_type_filter);
+    try testing.expectEqual(false, config.inactive_only);
+    try testing.expectEqual(false, config.artifacts_only);
+    try testing.expectEqual(false, config.deps_only);
+    try testing.expectEqual(false, config.verbose);
+}
+
+test "CleanupConfig - custom configuration" {
+    const config = CleanupConfig{
+        .dry_run = true,
+        .strategy = .aggressive,
+        .project_type_filter = .nodejs,
+        .inactive_only = true,
+        .artifacts_only = true,
+        .verbose = true,
+    };
+
+    try testing.expectEqual(true, config.dry_run);
+    try testing.expectEqual(CleanupStrategy.aggressive, config.strategy);
+    try testing.expectEqual(ProjectType.nodejs, config.project_type_filter.?);
+    try testing.expectEqual(true, config.inactive_only);
+    try testing.expectEqual(true, config.artifacts_only);
+    try testing.expectEqual(true, config.verbose);
+}
+
+test "workspace cleanup - help text includes cleanup command" {
+    const cmd = workspace.getCommand();
+    try testing.expectEqualStrings("workspace", cmd.name);
+    try testing.expect(cmd.description.len > 0);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1170,6 +1170,7 @@ test {
     _ = @import("commands/watch_test.zig");
     _ = @import("commands/watch_rules_test.zig");
     _ = @import("commands/workspace_test.zig");
+    _ = @import("commands/workspace_cleanup_test.zig");
     _ = @import("core/utils_test.zig");
     _ = @import("core/export.zig");
 }


### PR DESCRIPTION
## Summary
Implements comprehensive workspace cleanup functionality with multiple strategies and fine-grained control options for the `workspace` command.

## Features
- ✅ Three cleanup strategies: conservative, moderate, aggressive
- ✅ Selective cleanup by project type (nodejs, python, rust, zig, go, java)
- ✅ Separate control for artifacts and dependencies (`--artifacts-only`, `--deps-only`)
- ✅ Dry-run mode for safe previewing
- ✅ Inactive project filtering
- ✅ Detailed cleanup reporting with verbose mode

## Cleanup Strategies

**Conservative** (default):
- Only cleans build artifacts from inactive projects
- Safest option, preserves all active projects and dependencies

**Moderate**:
- Cleans build artifacts + dependencies from inactive projects
- Good balance between safety and space savings

**Aggressive**:
- Cleans build artifacts + dependencies from ALL projects
- Maximum space recovery, use with caution

## What Gets Cleaned

The cleanup command safely removes language-specific build artifacts and dependencies:

- **Node.js**: `node_modules`, `dist`, `build`, `.next`, `.nuxt`
- **Python**: `venv`, `.venv`, `__pycache__`, `dist`
- **Rust**: `target`
- **Zig**: `zig-cache`, `zig-out`
- **Go**: `vendor`
- **Java**: `target`, `build`, `.gradle`

## Usage Examples

```bash
# Preview what would be cleaned (safe)
zigstack workspace cleanup --dry-run ~/Code

# Clean inactive projects with moderate strategy
zigstack workspace cleanup --strategy moderate --inactive-only ~/Code

# Clean only Node.js projects' build artifacts
zigstack workspace cleanup --project-type nodejs --artifacts-only ~/Code

# Aggressive cleanup with verbose output
zigstack workspace cleanup --strategy aggressive --verbose ~/Code
```

## Implementation

- Extended `workspace.zig` with cleanup structures and functions
- Added comprehensive argument parsing for all cleanup options
- Implemented safe directory deletion with error handling
- Created detailed reporting with size formatting
- Added unit tests for cleanup functionality

## Testing

All tests pass including:
- ✅ Unit tests for CleanupStrategy enum
- ✅ Unit tests for CleanupConfig defaults and custom values
- ✅ Manual testing with real project directories
- ✅ Verified dry-run mode (no actual deletion)
- ✅ Verified actual cleanup (files correctly removed)
- ✅ Tested all filtering options (project type, strategy, artifacts/deps)

Resolves #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)